### PR TITLE
Use const instead of var

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function blobToBuffer (blob, cb) {
     throw new Error('second argument must be a function')
   }
 
-  var reader = new FileReader()
+  const reader = new FileReader()
 
   function onLoadEnd (e) {
     reader.removeEventListener('loadend', onLoadEnd, false)

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,9 +1,9 @@
 /* global Blob */
 
-var toBuffer = require('../')
-var test = require('tape')
+const toBuffer = require('../')
+const test = require('tape')
 
-var blob = new Blob([new Uint8Array([1, 2, 3])], { type: 'application/octet-binary' })
+const blob = new Blob([new Uint8Array([1, 2, 3])], { type: 'application/octet-binary' })
 
 test('Basic tests', function (t) {
   toBuffer(blob, function (err, buffer) {


### PR DESCRIPTION
Use `const` instead of `var` to conform to the [`no-var`](https://eslint.org/docs/rules/no-var) ESLint rule which is coming in a future version of [JavaScript Standard Style](https://standardjs.com). See https://github.com/standard/eslint-config-standard/pull/152.