### PR TITLE
convert anything to Buffer with promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,9 @@
 Say you're using the ['buffer'](https://github.com/feross/buffer) module on npm, or
 [browserify](http://browserify.org/) and you're working with lots of binary data.
 
-Unfortunately, sometimes the browser or someone else's API gives you a `Blob`. Silly
-browser. How do you convert it to a `Buffer`?
+How do you convert it to a `Buffer`?
 
-Something with a goofy `FileReader` thingy... Time to Google for it yet again... There must be a better way!
-
-***There is! Simply use this module!***
+***Simply use this module!***
 
 Works in the browser. This module is used by [WebTorrent](http://webtorrent.io)!
 
@@ -34,14 +31,12 @@ npm install blob-to-buffer
 ### usage
 
 ```js
-var toBuffer = require('blob-to-buffer')
+const toBuffer = require('blob-to-buffer')
 
 // Get a Blob somehow...
-var blob = new Blob([ new Uint8Array([1, 2, 3]) ], { type: 'application/octet-binary' })
+const blob = new Blob([ new Uint8Array([1, 2, 3]) ])
 
-toBuffer(blob, function (err, buffer) {
-  if (err) throw err
-
+toBuffer(blob).then(buffer => {
   buffer[0] // => 1
   buffer.readUInt8(1) // => 2
 })

--- a/index.js
+++ b/index.js
@@ -1,21 +1,3 @@
-/* global Blob, FileReader */
+/* global Response, Buffer */
 
-module.exports = function blobToBuffer (blob, cb) {
-  if (typeof Blob === 'undefined' || !(blob instanceof Blob)) {
-    throw new Error('first argument must be a Blob')
-  }
-  if (typeof cb !== 'function') {
-    throw new Error('second argument must be a function')
-  }
-
-  const reader = new FileReader()
-
-  function onLoadEnd (e) {
-    reader.removeEventListener('loadend', onLoadEnd, false)
-    if (e.error) cb(e.error)
-    else cb(null, Buffer.from(reader.result))
-  }
-
-  reader.addEventListener('loadend', onLoadEnd, false)
-  reader.readAsArrayBuffer(blob)
-}
+module.exports = anything => new Response(anything).arrayBuffer().then(Buffer.from)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blob-to-buffer",
   "description": "Convert a Blob to a Buffer",
-  "version": "1.2.8",
+  "version": "2.0.0",
   "author": {
     "name": "Feross Aboukhadijeh",
     "email": "feross@feross.org",

--- a/test/basic.js
+++ b/test/basic.js
@@ -3,22 +3,11 @@
 const toBuffer = require('../')
 const test = require('tape')
 
-const blob = new Blob([new Uint8Array([1, 2, 3])], { type: 'application/octet-binary' })
+const blob = new Blob([new Uint8Array([1, 2, 3])])
 
 test('Basic tests', function (t) {
-  toBuffer(blob, function (err, buffer) {
-    if (err) throw err
+  toBuffer(blob).then(buffer => {
     t.deepEqual(buffer, Buffer.from([1, 2, 3]))
     t.end()
   })
-})
-
-test('Callback error on invalid arguments', function (t) {
-  t.throws(function () {
-    toBuffer({ blah: 1 }, function () {})
-  })
-  t.throws(function () {
-    toBuffer(blob)
-  })
-  t.end()
 })


### PR DESCRIPTION
`Response` works in more browser
`blob.arrayBuffer()` requires a polyfill

choose to use Response

**Breaking change**: 
Use promise instead of callback
Bumped major version

closes #1 